### PR TITLE
[검색결과페이지 / 필터] 비동기 처리 이전에 NoDisplay가 렌더링 되는 문제

### DIFF
--- a/src/components/Header/Header.styled.tsx
+++ b/src/components/Header/Header.styled.tsx
@@ -20,7 +20,7 @@ export const StyledHeader = styled.header<headerprops>`
         : 'none'
       : '0 4px 11px rgb(0 0 0 / 10%)'};
   position: fixed;
-  z-index: 99;
+  z-index: 101;
   width: 100%;
   top: 0;
   left: 0;

--- a/src/pages/SearchResult/index.tsx
+++ b/src/pages/SearchResult/index.tsx
@@ -19,13 +19,15 @@ const SearchResult = () => {
 
   const [fetchData, setFetchData] = useState<Array<any>>([]);
   const [fetchFilteredData, setFetchFilteredData] = useState<Array<any>>([]);
+  const [loadingDataIsZero, setLoadingDataIsZero] = useState<boolean>(false);
 
-  console.log(inputSearchKeyword);
   useEffect(() => {
+    setLoadingDataIsZero(false);
     const fetchSearchData = async () => {
       const result = await getSearchData(inputSearchKeyword);
       result.sort((a, b) => b.score - a.score);
-      // console.log(result);
+      console.log(result);
+      if (result.length <= 0) setLoadingDataIsZero(true);
       setFetchData(result);
       setFetchFilteredData(result);
     };
@@ -41,7 +43,7 @@ const SearchResult = () => {
               <Restaurant key={elem.id} info={elem} cnt={3}></Restaurant>
             ))}
         </ul>
-        {fetchData.length === 0 && (
+        {loadingDataIsZero && (
           <span css={NoDisplay}>
             '{inputSearchKeyword}' 키워드와 일치하는 검색 결과가 없습니다!
           </span>


### PR DESCRIPTION
## Issue Number
#186 
## Proposed Changes
feat: filter component's rendering, when Data is 0

    - add loadingDataIsZero state
    - when First fetchData setLoadingDataisZero to false
    - so None display span doesn't see when Data is more than 1